### PR TITLE
cEOS: eAPI over https/443, replacing http/6021

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: netclab
 description: Helm chart to deploy a network lab on Kubernetes
 type: application
-version: 0.5.8
-appVersion: "0.5.8"
+version: 0.5.9
+appVersion: "0.5.9"
 
 maintainers:
 - name: M.Bakalarski

--- a/templates/ceos/ceos-startup-config.yaml
+++ b/templates/ceos/ceos-startup-config.yaml
@@ -8,7 +8,7 @@ data:
     username arista privilege 15 secret 0 arista
     !
     management api http-commands
-      protocol http port 6021
+      protocol https
       no shutdown
     !
     management security
@@ -49,7 +49,6 @@ data:
        260 permit udp any any eq lsp-ping
        270 permit udp any eq lsp-ping any range 51900 51999
        280 permit tcp any any eq 6020
-       290 permit tcp any any eq 6021
     !
     system control-plane
        ip access-group custom-cp in

--- a/templates/ceos/ceos.yaml
+++ b/templates/ceos/ceos.yaml
@@ -87,10 +87,10 @@ spec:
     protocol: TCP
     port: 6020
     targetPort: 6020
-  - name: jsonrpc
+  - name: eapi
     protocol: TCP
-    port: 6021
-    targetPort: 6021
+    port: 443
+    targetPort: 443
   - name: ssh
     protocol: TCP
     port: 22
@@ -127,7 +127,7 @@ spec:
         - |
             echo "Attempting certificate generation..."
 
-            if ! curl -s -u arista:arista http://{{ .name }}:6021/command-api \
+            if ! curl -sk -u arista:arista https://{{ .name }}/command-api \
                  -H "Content-Type: application/json" \
                  -d @/tmp/cmds ; then
               echo "Curl failed, exiting with error"


### PR DESCRIPTION
cEOS bootstrapped eAPI on http/6021, but AVD renders `protocol https` — so the
first config pushed to a node wiped the transport it arrived over. Bootstrapping
what AVD renders makes a full `configure replace` transport-neutral.

Service 6021 → 443, cert job follows. Verified on kind.

**Breaking:** the Service no longer exposes 6021.