### PR TITLE
cEOS: make the RESTCONF bootstrap actually reach a running server

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: netclab
 description: Helm chart to deploy a network lab on Kubernetes
 type: application
-version: 0.5.9
-appVersion: "0.5.9"
+version: 0.5.10
+appVersion: "0.5.10"
 
 maintainers:
 - name: M.Bakalarski

--- a/templates/ceos/ceos-cmds.yaml
+++ b/templates/ceos/ceos-cmds.yaml
@@ -3,14 +3,53 @@ kind: ConfigMap
 metadata:
   name: ceos-cmds
 data:
+  # Generate the RESTCONF certificate, then re-apply the SSL profile that uses
+  # it. The second half is not redundant.
+  #
+  # The startup-config configures `ssl profile restconf` before this Job runs,
+  # so at boot the profile references a certificate that does not exist yet and
+  # EOS marks it invalid. Creating the certificate afterwards does not revisit
+  # that verdict: the profile stays invalid, `management api restconf` reports
+  # "SSL profile not in valid state", and nothing ever listens on 6020.
+  #
+  # Only a config change re-evaluates the profile -- and re-entering the same
+  # `certificate ... key ...` line is a no-op, so it changes nothing. Hence the
+  # explicit `no ssl profile` before re-adding it: that is the one sequence that
+  # makes EOS look at the certificate again, and it is idempotent on re-runs.
   cmds: |
     {
         "jsonrpc": "2.0",
         "method": "runCmds",
         "params": {
             "version": 1,
-            "cmds": ["enable", "security pki certificate generate self-signed restconf.crt key restconf.key generate rsa 2048 parameters common-name restconf"],
+            "cmds": [
+                "enable",
+                "security pki certificate generate self-signed restconf.crt key restconf.key generate rsa 2048 parameters common-name restconf",
+                "configure",
+                "management security",
+                "no ssl profile restconf",
+                "ssl profile restconf",
+                "certificate restconf.crt key restconf.key",
+                "end"
+            ],
             "format": "json"
         },
         "id": 1
+    }
+  # The Job's gate. eAPI reports a failed command inside an HTTP 200, so a
+  # successful POST says nothing about whether RESTCONF actually came up --
+  # only this does. `enabled` is true exactly when the server is listening.
+  verify: |
+    {
+        "jsonrpc": "2.0",
+        "method": "runCmds",
+        "params": {
+            "version": 1,
+            "cmds": [
+                "enable",
+                "show management api restconf"
+            ],
+            "format": "json"
+        },
+        "id": 2
     }

--- a/templates/ceos/ceos.yaml
+++ b/templates/ceos/ceos.yaml
@@ -125,16 +125,53 @@ spec:
         - /bin/sh
         - -c
         - |
-            echo "Attempting certificate generation..."
+            post() {
+              curl -sk --fail-with-body -u arista:arista \
+                   https://{{ .name }}/command-api \
+                   -H "Content-Type: application/json" -d @"$1"
+            }
 
-            if ! curl -sk -u arista:arista https://{{ .name }}/command-api \
-                 -H "Content-Type: application/json" \
-                 -d @/tmp/cmds ; then
-              echo "Curl failed, exiting with error"
-              exit 1
-            fi
+            # Wait for the device here rather than by exiting and letting the
+            # Job restart the container. With restartPolicy OnFailure the whole
+            # cEOS boot has to fit inside backoffLimit restarts of a growing
+            # backoff -- a budget that depends on how fast the node boots, and
+            # that a slow device silently loses. Waiting in one attempt makes
+            # the timeout explicit and leaves backoffLimit for real failures.
+            deadline=$(( $(date +%s) + 600 ))
 
-            echo "Certificate generated successfully."
+            echo "Attempting certificate generation on {{ .name }}..."
+
+            # Neither half of this check is optional. curl exits 0 on an HTTP
+            # 404, and on a cold boot nginx answers on 443 with "Page not
+            # found" for a while before eAPI is registered -- so the exit code
+            # alone would report success without ever having reached the
+            # device. --fail-with-body makes that a failure. The `"result"`
+            # test covers the other half: eAPI reports a *failed command*
+            # inside an HTTP 200, as an `error` member.
+            until out=$(post /tmp/cmds) && echo "$out" | grep -q '"result"' ; do
+              if [ "$(date +%s)" -ge "$deadline" ] ; then
+                echo "eAPI never became ready on {{ .name }}: $out"
+                exit 1
+              fi
+              echo "eAPI not ready yet, retrying..."
+              sleep 10
+            done
+
+            echo "Certificate generated. Verifying RESTCONF came up..."
+
+            # And the commands succeeding still does not mean RESTCONF is
+            # serving: the SSL profile is re-evaluated asynchronously, so ask
+            # the device until it says the server is enabled.
+            until out=$(post /tmp/verify) && echo "$out" | grep -q '"enabled":true' ; do
+              if [ "$(date +%s)" -ge "$deadline" ] ; then
+                echo "RESTCONF is not enabled on {{ .name }}: $out"
+                exit 1
+              fi
+              echo "RESTCONF not up yet, retrying..."
+              sleep 5
+            done
+
+            echo "RESTCONF is up on {{ .name }}."
 
 {{- end }}
 {{- end }}


### PR DESCRIPTION
RESTCONF never came up on a cEOS node. The startup-config configures `ssl profile restconf` before the Job that creates the certificate it names, so EOS marks the profile invalid at boot — and creating the certificate afterwards does not revisit that verdict. `management api restconf` stayed at *"SSL profile not in valid state"*, nothing listened on 6020, and the Job reported success throughout.

Found while exercising netclab-xp's RESTCONF scenarios against a real lab: every `Request` failed to connect, and `ss -tnl` on the device showed only 443.

## Three fixes, each of which the lab needed on its own

**Re-apply the SSL profile after generating the certificate.** Only a config change re-evaluates the profile, and re-entering the same `certificate ... key ...` line is a no-op — so the profile is removed and re-added. Idempotent on re-runs.

**Make the Job's checks honest.** `curl` exits 0 on an HTTP 404, and during boot nginx answers on 443 with `Page not found` before eAPI is registered — so the old `if ! curl` reported *"Certificate generated successfully"* without ever having reached the device. Now `--fail-with-body` plus a check for `"result"`, and a second request that asks the device whether RESTCONF is actually enabled.

**Wait for the device in the container, not via `restartPolicy`.** With `OnFailure` the whole cEOS boot had to fit inside `backoffLimit` restarts of a growing backoff. One node made it on the 3rd restart; the other exhausted all 6 and the Job failed. The wait is now an explicit 600s deadline, which leaves `backoffLimit` for real failures.

## Verified

kind, two cEOS 4.36.1F nodes, cold boot, no manual intervention:

- both Jobs `Complete` in ~2min with **0 restarts** (previously: one Job `Failed`, one needed 2 restarts)
- both logs show `RESTCONF not up yet, retrying...` before succeeding — the SSL profile is re-evaluated asynchronously, so that second loop is load-bearing too
- both devices answer `HTTP 200` on RESTCONF 6020 and eAPI 443

Note: `chart-install-test.yml` installs with the default values, whose only node is srlinux — so this cEOS path is not covered by CI.

Chart version bumped to 0.5.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)